### PR TITLE
Add hspec as a test dependency

### DIFF
--- a/pandoc-emphasize-code.cabal
+++ b/pandoc-emphasize-code.cabal
@@ -67,5 +67,6 @@ test-suite filter-tests
                    , tasty-hunit
                    , tasty-hspec
                    , tasty-discover
+                   , hspec
                    , text                 >= 1.2      && < 1.3
     default-language: Haskell2010

--- a/test/Text/Pandoc/Filter/EmphasizeCode/ChunkingTest.hs
+++ b/test/Text/Pandoc/Filter/EmphasizeCode/ChunkingTest.hs
@@ -4,6 +4,7 @@
 module Text.Pandoc.Filter.EmphasizeCode.ChunkingTest where
 
 import           Test.Tasty.Hspec
+import           Test.Hspec (it, shouldBe)
 
 import           Text.Pandoc.Filter.EmphasizeCode.Chunking
 import           Text.Pandoc.Filter.EmphasizeCode.Range

--- a/test/Text/Pandoc/Filter/EmphasizeCode/ParserTest.hs
+++ b/test/Text/Pandoc/Filter/EmphasizeCode/ParserTest.hs
@@ -8,6 +8,7 @@ import           Data.List.NonEmpty
 import qualified Data.Text                                       as T
 
 import           Test.Tasty.Hspec
+import           Test.Hspec (it, shouldBe, shouldSatisfy)
 import           Text.Pandoc.Filter.EmphasizeCode.Parser
 import           Text.Pandoc.Filter.EmphasizeCode.Position
 import           Text.Pandoc.Filter.EmphasizeCode.Range

--- a/test/Text/Pandoc/Filter/EmphasizeCode/RangeTest.hs
+++ b/test/Text/Pandoc/Filter/EmphasizeCode/RangeTest.hs
@@ -6,6 +6,7 @@ import qualified Data.HashMap.Strict                             as HashMap
 import           Data.Maybe                                      (mapMaybe)
 import           Data.Tuple                                      (swap)
 import           Test.Tasty.Hspec
+import           Test.Hspec (it, shouldThrow, anyException, Expectation, shouldBe)
 
 import           Text.Pandoc.Filter.EmphasizeCode.Position
 import           Text.Pandoc.Filter.EmphasizeCode.Range

--- a/test/Text/Pandoc/Filter/EmphasizeCodeTest.hs
+++ b/test/Text/Pandoc/Filter/EmphasizeCodeTest.hs
@@ -4,6 +4,7 @@
 module Text.Pandoc.Filter.EmphasizeCodeTest where
 
 import           Test.Tasty.Hspec
+import           Test.Hspec (it, shouldReturn)
 
 import qualified Text.Pandoc.Filter.EmphasizeCode as Filter
 import           Text.Pandoc.JSON


### PR DESCRIPTION
`tasty-hspec` removed the re-export of `Test.Hspec` with version 1.1.7, which made the test suite fail to compile. This commit adds `hspec` as a test dependency and adds explicit imports from `Test.Hspec` where needed.

https://github.com/mitchellwrosen/tasty-hspec/blob/main/CHANGELOG.md#117---2021-05-12